### PR TITLE
make task factory support iterator

### DIFF
--- a/examples/task_factory.php
+++ b/examples/task_factory.php
@@ -50,17 +50,9 @@ class TaskFactory
 
     public function fetchTask()
     {
-        $task = $this->_doFetchTask();
-        if ($task) {
-            $this->_lastIsNull == false;
-            return $task;
-        }
-        if (! $this->_lastIsNull) {
-            $this->_lastIsNull = true;
-            return null;
-        }
-        sleep(1);
-        return null;
+       while($this->_index < count($this->_plan)){
+          yield $this->_doFetchTask();
+       }
     }
 
     public function _doFetchTask()


### PR DESCRIPTION
TaskFactory factory使用iterator会更加易读和容易构建。示例中通过index成员变量迭代的做法复杂晦涩，完全可以用iterator替代。
