### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#QPM [![Build Status](https://secure.travis-ci.org/Comos/qpm.png)](http://travis-ci.org/Comos/qpm)
+# QPM [![Build Status](https://secure.travis-ci.org/Comos/qpm.png)](http://travis-ci.org/Comos/qpm)
 
 QPM全名是 Quick(or Q's) Process Management Framework for PHP.
 PHP 是强大的web开发语言，以至于大家常常忘记PHP 可以用来开发健壮的命令行（CLI）程序以至于daemon程序。


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
